### PR TITLE
Support driver-toolkit image of new OpenShift releases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,6 @@
-FROM quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:0f046d61ecc9855e0b7d1846d645661b32654a358c1530dd20efb31f65686f8d
+FROM quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:4a197c0dfdf5ca30ff48d6eee25960001dbaa82c86b6dd920c6acc47f5680701
 ARG NVIDIA_INSTALLER_BINARY
 ENV NVIDIA_INSTALLER_BINARY=${NVIDIA_INSTALLER_BINARY:-NVIDIA-Linux-x86_64-470.63-vgpu-kvm.run}
-
-RUN dnf -y install git make sudo gcc \
-&& dnf clean all \
-&& rm -rf /var/cache/dnf
 
 RUN mkdir -p /root/nvidia
 WORKDIR /root/nvidia

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This container image installs the NVIDIA's generic Linux GRID driver on Red Hat 
 ### Obtaining the driver toolkit base image
 ```
 $ oc adm release info --image-for=driver-toolkit
-quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:e0f9b9154538af082596f60af99290b5a751e61fd61100912defb71b6cac15c6
+quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:4a197c0dfdf5ca30ff48d6eee25960001dbaa82c86b6dd920c6acc47f5680701
 ```
 
 ### Configure


### PR DESCRIPTION
The driver-toolkit container image now contains all the tools required
to build the nvidia kernel driver. Additionally it does not come with
pre-configured yum repositories anymore, hence `dnf install` command
fail.

Relevant for OpenShift versions:
- 4.7.45+ (2022-03-15)
- 4.8.34+ (2022-03-09)
- 4.9.24+ (2022-03-10)
- 4.10.4+ (2022-03-10)

See: RHBZ#2070998.